### PR TITLE
Force the scheduled task to run immediately

### DIFF
--- a/lib/kitchen/provisioner/chef_zero_scheduled_task.rb
+++ b/lib/kitchen/provisioner/chef_zero_scheduled_task.rb
@@ -85,7 +85,7 @@ try {
   $npipeServer = new-object System.IO.Pipes.NamedPipeServerStream('task', 
     [System.IO.Pipes.PipeDirection]::In)
   $pipeReader = new-object System.IO.StreamReader($npipeServer)
-  schtasks /run /tn "chef-tk"
+  schtasks /run /tn "chef-tk" /i
   $npipeserver.waitforconnection()
   $host.ui.writeline('Connected to the scheduled task.')
   while ($npipeserver.IsConnected) {


### PR DESCRIPTION
When the vm is run from a host with a battery (like a dev laptop) and that the laptop isn't plugged, the task is only queued. 

This forces the task to run immediately.
